### PR TITLE
Enable support interface aliases ex. eth0:0

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function parse(src) {
 
   blocks.forEach(function(block) {
     var firstline = block[0].toString();
-    var coionIdx = firstline.indexOf(":");
+    var coionIdx = firstline.indexOf(": "); // With space to support interface aliases ex. eth0:0
     var name = firstline.slice(0, coionIdx);
     var conf = block.slice(1);
     var flagsline = firstline.slice(coionIdx + 1).trim();


### PR DESCRIPTION
Hi @PsyTae,

I changed only the first split to find the ':' char after the interface name to ': ' (with space).

In this manner you could support network interface aliases.
In example eth0:0.

I hope I'm doing right.
Bye